### PR TITLE
Move bundle clean below bundle install

### DIFF
--- a/jekyll/_cci2/caching.md
+++ b/jekyll/_cci2/caching.md
@@ -384,7 +384,6 @@ To prevent this behavior, add a step that cleans Bundler before restoring depend
 
 ```yaml
 steps:
-  - run: bundle clean --force
   - restore_cache:
       keys:
         # when lock file changes, use increasingly general patterns to restore cache
@@ -392,6 +391,7 @@ steps:
         - v1-gem-cache-{{ arch }}-{{ .Branch }}-
         - v1-gem-cache-{{ arch }}-
   - run: bundle install
+  - run: bundle clean --force
   - save_cache:
       paths:
         - ~/.bundle


### PR DESCRIPTION
# Description
Move `- run: bundle clean --force` below `- run: bundle install` base on https://circleci.com/developer/orbs/orb/later/ruby-rails-setup this example (line 53-62)
# Reasons
If bundle clean execute first it will through an error 
<img width="1128" alt="ios_build__4303__-_insidelabs_inside-laax" src="https://user-images.githubusercontent.com/22459674/112520672-52e7ad80-8da4-11eb-900d-dc0d714ade42.png">
